### PR TITLE
Extend calibration dataset options

### DIFF
--- a/LLMPruner/datasets/example_samples.py
+++ b/LLMPruner/datasets/example_samples.py
@@ -39,10 +39,76 @@ def get_bookcorpus(tokenizer, n_samples, seq_len):
         tokenized_samples.append(tokenized_sample.input_ids[:, i:i+seq_len])
     return torch.cat(tokenized_samples, dim=0 )
 
+def get_wikipedia(tokenizer, n_samples, seq_len):
+    """Load the first shard of the cleaned English Wikipedia from 2023-11-01."""
+    traindata = load_dataset(
+        'wikimedia/wikipedia',
+        data_files={'train': '20231101.en/train-00000-of-00041.parquet'},
+        split='train'
+    )
+
+    tokenized_samples, history = [], []
+    for _ in range(n_samples):
+        while True:
+            i = random.randint(0, len(traindata) - 1)
+            tokenized_sample = tokenizer(traindata[i]['text'], return_tensors='pt')
+            if tokenized_sample.input_ids.shape[1] >= seq_len and i not in history:
+                history.append(i)
+                break
+        i = random.randint(0, tokenized_sample.input_ids.shape[1] - seq_len)
+        tokenized_samples.append(tokenized_sample.input_ids[:, i:i+seq_len])
+    return torch.cat(tokenized_samples, dim=0)
+
+def get_slimpajama(tokenizer, n_samples, seq_len):
+    """Load a shard from the SlimPajama dataset."""
+    traindata = load_dataset(
+        'DKYoon/SlimPajama-6B',
+        data_files={'train': 'data/train-00000-of-00052.parquet'},
+        split='train'
+    )
+
+    tokenized_samples, history = [], []
+    for _ in range(n_samples):
+        while True:
+            i = random.randint(0, len(traindata) - 1)
+            tokenized_sample = tokenizer(traindata[i]['text'], return_tensors='pt')
+            if tokenized_sample.input_ids.shape[1] >= seq_len and i not in history:
+                history.append(i)
+                break
+        i = random.randint(0, tokenized_sample.input_ids.shape[1] - seq_len)
+        tokenized_samples.append(tokenized_sample.input_ids[:, i:i+seq_len])
+    return torch.cat(tokenized_samples, dim=0)
+
+def get_dclm(tokenizer, n_samples, seq_len):
+    """Load a subset of the DCLM dataset used for DCLM-7B pre-training."""
+    traindata = load_dataset(
+        'coai/dclm-baseline-subset_100k',
+        data_files={'train': 'data/train-00000-of-00002.parquet'},
+        split='train'
+    )
+
+    tokenized_samples, history = [], []
+    for _ in range(n_samples):
+        while True:
+            i = random.randint(0, len(traindata) - 1)
+            tokenized_sample = tokenizer(traindata[i]['text'], return_tensors='pt')
+            if tokenized_sample.input_ids.shape[1] >= seq_len and i not in history:
+                history.append(i)
+                break
+        i = random.randint(0, tokenized_sample.input_ids.shape[1] - seq_len)
+        tokenized_samples.append(tokenized_sample.input_ids[:, i:i+seq_len])
+    return torch.cat(tokenized_samples, dim=0)
+
 def get_examples(dataset, tokenizer, n_samples, seq_len = 128):
     if dataset == 'c4':
         return get_c4(tokenizer, n_samples, seq_len)
     elif dataset == 'bookcorpus':
         return get_bookcorpus(tokenizer, n_samples, seq_len)
+    elif dataset == 'wikipedia':
+        return get_wikipedia(tokenizer, n_samples, seq_len)
+    elif dataset == 'slimpajama':
+        return get_slimpajama(tokenizer, n_samples, seq_len)
+    elif dataset == 'dclm':
+        return get_dclm(tokenizer, n_samples, seq_len)
     else:
         raise NotImplementedError

--- a/moreauprune.py
+++ b/moreauprune.py
@@ -162,11 +162,11 @@ def main(args):
     
         cnt = 0
         if not args.moredata:
-            example_prompts = get_examples('bookcorpus', tokenizer, args.num_examples, seq_len = 2048).to(args.device)
+            example_prompts = get_examples(args.calib_dataset, tokenizer, args.num_examples, seq_len = 2048).to(args.device)
         for i in range(args.iterative_steps):
             gc.collect()
             if args.moredata:
-                example_prompts = get_examples('bookcorpus', tokenizer, args.num_examples, seq_len = 2048).to(args.device)
+                example_prompts = get_examples(args.calib_dataset, tokenizer, args.num_examples, seq_len = 2048).to(args.device)
             if pruner_type in ['taylor']:
                 logger.log("Start Backwarding in iterative steps = {}...".format(i))
                 model.zero_grad()  
@@ -276,7 +276,7 @@ def main(args):
         for i in range(args.iterative_steps):
 
             if pruner_type in ['taylor']:
-                example_prompts = get_examples('bookcorpus', tokenizer, 10, seq_len = 64)
+                example_prompts = get_examples(args.calib_dataset, tokenizer, 10, seq_len = 64)
                 logger.log("Start Backwarding in iterative steps = {}...".format(i))
                 loss = model(example_prompts, labels=example_prompts).loss
                 logger.log("Loss = {}".format(loss))
@@ -397,6 +397,9 @@ if __name__ == "__main__":
     parser.add_argument('--lr', type=float, default=0.1, help='learning rate')
     parser.add_argument('--soft', type=float, default=5e-3, help='soft threshold')
     parser.add_argument('--moredata', action='store_true', help='if usemoredata')
+    parser.add_argument('--calib_dataset', type=str, default='bookcorpus',
+                        choices=['bookcorpus', 'c4', 'wikipedia', 'slimpajama', 'dclm'],
+                        help='dataset used for calibration')
 
     args = parser.parse_args()
 

--- a/scripts/prune_multi_seed.sh
+++ b/scripts/prune_multi_seed.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Repeatedly prune and evaluate using ten different random seeds.
+# Usage: bash scripts/prune_multi_seed.sh [calib_dataset]
+# Default calibration dataset is 'bookcorpus'.
+
+calib_dataset=${1:-bookcorpus}
+base_model=baffo32/decapoda-research-llama-7B-hf
+
+for seed in {1..10}; do
+    run_name="${calib_dataset}_seed${seed}"
+    echo "[RUN] pruning with seed ${seed} using ${calib_dataset}"
+
+    python moreauprune.py \
+        --pruning_ratio 0.25 \
+        --device cpu \
+        --eval_device cuda \
+        --block_wise \
+        --block_mlp_layer_start 4 \
+        --block_mlp_layer_end 30 \
+        --block_attention_layer_start 4 \
+        --block_attention_layer_end 30 \
+        --num_examples 10 \
+        --save_ckpt_log_name ${run_name} \
+        --pruner_type taylor \
+        --taylor param_first \
+        --save_model \
+        --base_model ${base_model} \
+        --test_after_train \
+        --iterative_steps 10 \
+        --std 0.05 \
+        --lamb 0.2 \
+        --lr 0.0002 \
+        --soft 0.000005 \
+        --seed ${seed} \
+        --calib_dataset ${calib_dataset}
+
+    CUDA_VISIBLE_DEVICES=0 bash scripts/evaluate_pretrain.sh ${base_model} prune_log/${run_name}
+done


### PR DESCRIPTION
## Summary
- allow selecting new calibration data sources via `--calib_dataset`
- implement dataset loaders for Wikipedia, SlimPajama and DCLM
- add helper script `prune_multi_seed.sh` to repeat pruning on multiple seeds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sacrebleu')*

------
https://chatgpt.com/codex/tasks/task_e_684973ec43288322b06b3c5fe6f2d013