### PR TITLE
Enable PPL evaluation on Alpaca dataset

### DIFF
--- a/LLMPruner/datasets/ppl_dataset.py
+++ b/LLMPruner/datasets/ppl_dataset.py
@@ -20,6 +20,13 @@ def get_ptb(seq_len, tokenizer):
     valdata = load_dataset('ptb_text_only', 'penn_treebank', split='validation')
     return traindata, valdata
 
+def get_alpaca(seq_len, tokenizer):
+    """Load the Alpaca dataset used for fine-tuning."""
+    traindata = load_dataset('yahma/alpaca-cleaned', split='train')
+    # The official dataset has no predefined validation split.  For perplexity
+    # evaluation we simply reuse the training data.
+    return traindata, traindata
+
 class IndexDataset(Dataset):
     def __init__(self, tensors):
         self.tensors = tensors
@@ -49,6 +56,9 @@ def get_loaders(name, tokenizer, seq_len=2048, batch_size = 8):
     if 'ptb' in name:
         train_data, test_data = get_ptb(seq_len, tokenizer)
         test_dataset = process_data(test_data, tokenizer, seq_len, 'sentence')
+    if 'alpaca' in name:
+        train_data, test_data = get_alpaca(seq_len, tokenizer)
+        test_dataset = process_data(test_data, tokenizer, seq_len, 'output')
 
     test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
     return train_data, test_loader

--- a/eval.py
+++ b/eval.py
@@ -56,7 +56,7 @@ def main(args):
     tokenizer.unk_token_id = 0
     model.eval()
 
-    ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb'], 128, device="cuda")
+    ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb', 'alpaca'], 128, device="cuda")
     print("PPL after pruning: {}".format(ppl))
     print("Memory Requirement: {} MiB\n".format(torch.cuda.memory_allocated()/1024/1024))
         

--- a/moreauprune.py
+++ b/moreauprune.py
@@ -82,7 +82,7 @@ def main(args):
                 result = tokenizer.decode(generation_output[0])
                 logger.log(result)
     
-        ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb'], args.max_seq_len, device=args.device)
+        ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb', 'alpaca'], args.max_seq_len, device=args.device)
         logger.log("PPL before pruning: {}".format(ppl))
 
     pruner_type = args.pruner_type.lower()
@@ -327,7 +327,7 @@ def main(args):
         
         logger.log("\n==================Finish================\n")
     
-    ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb'], args.max_seq_len, device=args.eval_device)
+    ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb', 'alpaca'], args.max_seq_len, device=args.eval_device)
     logger.log("PPL after pruning: {}".format(ppl))
     logger.log("Memory Requirement: {} MiB\n".format(torch.cuda.memory_allocated()/1024/1024))
 

--- a/moreaupruner_us.py
+++ b/moreaupruner_us.py
@@ -80,7 +80,7 @@ def main(args):
                 result = tokenizer.decode(generation_output[0])
                 logger.log(result)
     
-        ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb'], args.max_seq_len, device=args.device)
+        ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb', 'alpaca'], args.max_seq_len, device=args.device)
         logger.log("PPL before pruning: {}".format(ppl))
 
     pruner_type = args.pruner_type.lower()
@@ -244,7 +244,7 @@ def main(args):
         
         logger.log("\n==================Finish================\n")
     
-    ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb'], args.max_seq_len, device=args.eval_device)
+    ppl = PPLMetric(model, tokenizer, ['wikitext2', 'ptb', 'alpaca'], args.max_seq_len, device=args.eval_device)
     logger.log("PPL after pruning: {}".format(ppl))
     logger.log("Memory Requirement: {} MiB\n".format(torch.cuda.memory_allocated()/1024/1024))
 


### PR DESCRIPTION
## Summary
- support the Alpaca dataset in `PPLMetric` helpers
- evaluate PPL on Alpaca in pruning scripts and eval utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sacrebleu')*

------
https://chatgpt.com/codex/tasks/task_e_684bc2b197cc8322acf2fabeb6f75844